### PR TITLE
Update NewMetricsHandler to wrap Handler, no namespace, better metrics

### DIFF
--- a/health/example_test.go
+++ b/health/example_test.go
@@ -176,10 +176,10 @@ func Example_metrics() {
 	// Connection: close
 	// Content-Type: text/plain; version=0.0.4; charset=utf-8
 	//
-	// # HELP healthcheck_healthy Indicates if check is healthy (1 is healthy, 0 is unhealthy)
-	// # TYPE healthcheck_healthy gauge
-	// healthcheck_healthy{check="live",name="successful-check"} 1
-	// healthcheck_healthy{check="ready",name="failing-check"} 0
+	// # HELP healthcheck Indicates if check is healthy (1 is healthy, 0 is unhealthy)
+	// # TYPE healthcheck gauge
+	// healthcheck{check="live",name="successful-check"} 1
+	// healthcheck{check="ready",name="failing-check"} 0
 }
 
 func upstream() (*httptest.Server, *url.URL) {

--- a/health/example_test.go
+++ b/health/example_test.go
@@ -142,8 +142,8 @@ func Example_metrics() {
 	registry := prometheus.NewRegistry()
 
 	// Create a metrics-exposing Handler for the Prometheus registry
-	// The healthcheck related metrics will be prefixed with the provided namespace
-	health := NewMetricsHandler(registry, "example")
+	// It wraps the default handler to add metrics.
+	health := NewMetricsHandler(NewHandler(), registry)
 
 	// Add a simple readiness check that always fails.
 	health.AddReadinessCheck("failing-check", func() error {
@@ -156,30 +156,30 @@ func Example_metrics() {
 	})
 
 	// Create an "admin" listener on 0.0.0.0:9402
-	adminMux := http.NewServeMux()
-	// go http.ListenAndServe("0.0.0.0:9402", adminMux)
+	internal := http.NewServeMux()
+	// go http.ListenAndServe("0.0.0.0:9402", internal)
 
 	// Expose prometheus metrics on /metrics
-	adminMux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	internal.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 
 	// Expose a liveness check on /live
-	adminMux.HandleFunc("/live", health.LiveEndpoint)
+	internal.HandleFunc("/live", health.LiveEndpoint)
 
 	// Expose a readiness check on /ready
-	adminMux.HandleFunc("/ready", health.ReadyEndpoint)
+	internal.HandleFunc("/ready", health.ReadyEndpoint)
 
 	// Make a request to the metrics endpoint and print the response.
-	fmt.Println(dumpRequest(adminMux, "GET", "/metrics"))
+	fmt.Println(dumpRequest(internal, "GET", "/metrics"))
 
 	// Output:
 	// HTTP/1.1 200 OK
 	// Connection: close
 	// Content-Type: text/plain; version=0.0.4; charset=utf-8
 	//
-	// # HELP example_healthy_error Current check status has error (0 indicates no error, 1 indicates error)
-	// # TYPE example_healthy_error gauge
-	// example_healthy_error{check="live",name="successful-check"} 0
-	// example_healthy_error{check="ready",name="failing-check"} 1
+	// # HELP healthcheck_healthy Indicates if check is healthy (1 is healthy, 0 is unhealthy)
+	// # TYPE healthcheck_healthy gauge
+	// healthcheck_healthy{check="live",name="successful-check"} 1
+	// healthcheck_healthy{check="ready",name="failing-check"} 0
 }
 
 func upstream() (*httptest.Server, *url.URL) {

--- a/health/metrics_handler.go
+++ b/health/metrics_handler.go
@@ -57,7 +57,7 @@ func (h *metricsHandler) ReadyEndpoint(w http.ResponseWriter, r *http.Request) {
 func (h *metricsHandler) wrap(labels prometheus.Labels, check Check) Check {
 	h.registry.MustRegister(prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
-			Name:        "healthcheck_healthy",
+			Name:        "healthcheck",
 			Help:        "Indicates if check is healthy (1 is healthy, 0 is unhealthy)",
 			ConstLabels: labels,
 		},

--- a/health/metrics_handler_test.go
+++ b/health/metrics_handler_test.go
@@ -61,25 +61,25 @@ func TestNewMetricsHandler(t *testing.T) {
 	lines := strings.Split(rr.Body.String(), "\n")
 	var relevantLines []string
 	for _, line := range lines {
-		if strings.HasPrefix(line, "healthcheck_healthy") {
+		if strings.HasPrefix(line, "healthcheck") {
 			relevantLines = append(relevantLines, line)
 		}
 	}
 	sort.Strings(relevantLines)
 	actualMetrics := strings.Join(relevantLines, "\n")
 	expectedMetrics := strings.TrimSpace(`
-healthcheck_healthy{check="live",name="aaa"} 1
-healthcheck_healthy{check="live",name="bbb"} 1
-healthcheck_healthy{check="live",name="ccc"} 1
-healthcheck_healthy{check="live",name="ddd"} 0
-healthcheck_healthy{check="live",name="eee"} 0
-healthcheck_healthy{check="live",name="fff"} 0
-healthcheck_healthy{check="ready",name="aaa"} 1
-healthcheck_healthy{check="ready",name="bbb"} 1
-healthcheck_healthy{check="ready",name="ccc"} 1
-healthcheck_healthy{check="ready",name="ddd"} 0
-healthcheck_healthy{check="ready",name="eee"} 0
-healthcheck_healthy{check="ready",name="fff"} 0
+healthcheck{check="live",name="aaa"} 1
+healthcheck{check="live",name="bbb"} 1
+healthcheck{check="live",name="ccc"} 1
+healthcheck{check="live",name="ddd"} 0
+healthcheck{check="live",name="eee"} 0
+healthcheck{check="live",name="fff"} 0
+healthcheck{check="ready",name="aaa"} 1
+healthcheck{check="ready",name="bbb"} 1
+healthcheck{check="ready",name="ccc"} 1
+healthcheck{check="ready",name="ddd"} 0
+healthcheck{check="ready",name="eee"} 0
+healthcheck{check="ready",name="fff"} 0
 `)
 	if actualMetrics != expectedMetrics {
 		t.Errorf("expected metrics:\n%s\n\nactual metrics:\n%s\n", expectedMetrics, actualMetrics)

--- a/health/metrics_handler_test.go
+++ b/health/metrics_handler_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 func TestNewMetricsHandler(t *testing.T) {
-	handler := NewMetricsHandler(prometheus.DefaultRegisterer, "test")
+	reg := prometheus.NewRegistry()
+	handler := NewMetricsHandler(NewHandler(), reg)
 
 	for _, name := range []string{"aaa", "bbb", "ccc"} {
 		check := func() error {
@@ -49,7 +50,7 @@ func TestNewMetricsHandler(t *testing.T) {
 		handler.AddLivenessCheck(name, check)
 	}
 
-	metricsHandler := promhttp.Handler()
+	metricsHandler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})
 	req, err := http.NewRequest("GET", "/metrics", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -60,25 +61,25 @@ func TestNewMetricsHandler(t *testing.T) {
 	lines := strings.Split(rr.Body.String(), "\n")
 	var relevantLines []string
 	for _, line := range lines {
-		if strings.HasPrefix(line, "test_healthy_error") {
+		if strings.HasPrefix(line, "healthcheck_healthy") {
 			relevantLines = append(relevantLines, line)
 		}
 	}
 	sort.Strings(relevantLines)
 	actualMetrics := strings.Join(relevantLines, "\n")
 	expectedMetrics := strings.TrimSpace(`
-test_healthy_error{check="live",name="aaa"} 0
-test_healthy_error{check="live",name="bbb"} 0
-test_healthy_error{check="live",name="ccc"} 0
-test_healthy_error{check="live",name="ddd"} 1
-test_healthy_error{check="live",name="eee"} 1
-test_healthy_error{check="live",name="fff"} 1
-test_healthy_error{check="ready",name="aaa"} 0
-test_healthy_error{check="ready",name="bbb"} 0
-test_healthy_error{check="ready",name="ccc"} 0
-test_healthy_error{check="ready",name="ddd"} 1
-test_healthy_error{check="ready",name="eee"} 1
-test_healthy_error{check="ready",name="fff"} 1
+healthcheck_healthy{check="live",name="aaa"} 1
+healthcheck_healthy{check="live",name="bbb"} 1
+healthcheck_healthy{check="live",name="ccc"} 1
+healthcheck_healthy{check="live",name="ddd"} 0
+healthcheck_healthy{check="live",name="eee"} 0
+healthcheck_healthy{check="live",name="fff"} 0
+healthcheck_healthy{check="ready",name="aaa"} 1
+healthcheck_healthy{check="ready",name="bbb"} 1
+healthcheck_healthy{check="ready",name="ccc"} 1
+healthcheck_healthy{check="ready",name="ddd"} 0
+healthcheck_healthy{check="ready",name="eee"} 0
+healthcheck_healthy{check="ready",name="fff"} 0
 `)
 	if actualMetrics != expectedMetrics {
 		t.Errorf("expected metrics:\n%s\n\nactual metrics:\n%s\n", expectedMetrics, actualMetrics)
@@ -86,7 +87,7 @@ test_healthy_error{check="ready",name="fff"} 1
 }
 
 func TestNewMetricsHandlerEndpoints(t *testing.T) {
-	handler := NewMetricsHandler(prometheus.NewRegistry(), "test")
+	handler := NewMetricsHandler(NewHandler(), prometheus.NewRegistry())
 	handler.AddReadinessCheck("fail", func() error {
 		return fmt.Errorf("failing readiness check")
 	})


### PR DESCRIPTION
From now on we should start prefixing this metric. It would be nice to have healthcheck_healthy on all projects, so that it kind of becomes like a up metric, that can be generically alerted on (especially for liveness, I think). Additionally healthy==1 and unhealthy==0 should make the metric more intuitive for Prometheus folks.