### PR TITLE
Rename package to healthcheck again (like original)

### DIFF
--- a/healthcheck/checks.go
+++ b/healthcheck/checks.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"context"

--- a/healthcheck/checks_test.go
+++ b/healthcheck/checks_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"net/http"

--- a/healthcheck/doc.go
+++ b/healthcheck/doc.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*
-Package healthcheck helps you implement Kubernetes liveness and readiness checks
+Package healthcheck helps you implement liveness and readiness checks
 for your application. It supports synchronous and asynchronous (background)
 checks. It can optionally report each check's status as a set of Prometheus
 gauge metrics for cluster-wide monitoring and alerting.
@@ -21,4 +21,4 @@ gauge metrics for cluster-wide monitoring and alerting.
 It also includes a small library of generic checks for DNS, TCP, and HTTP
 reachability as well as Goroutine usage.
 */
-package health
+package healthcheck

--- a/healthcheck/handler.go
+++ b/healthcheck/handler.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"encoding/json"

--- a/healthcheck/handler_test.go
+++ b/healthcheck/handler_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"errors"

--- a/healthcheck/metrics_handler.go
+++ b/healthcheck/metrics_handler.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"net/http"

--- a/healthcheck/metrics_handler_test.go
+++ b/healthcheck/metrics_handler_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"fmt"

--- a/healthcheck/timeout.go
+++ b/healthcheck/timeout.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"fmt"

--- a/healthcheck/timeout_test.go
+++ b/healthcheck/timeout_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"net"

--- a/healthcheck/types.go
+++ b/healthcheck/types.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package healthcheck
 
 import (
 	"net/http"


### PR DESCRIPTION
The name was quite nice, not sure why I moved away from it in the past.

Depends on #4 to merge first.