### PR TITLE
Create internalserver package that generates handler with index page

### DIFF
--- a/internalserver/example_test.go
+++ b/internalserver/example_test.go
@@ -1,0 +1,79 @@
+package internalserver
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"strings"
+
+	"github.com/metalmatze/signal/healthcheck"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func Example() {
+	registry := prometheus.NewRegistry()
+	healthchecks := healthcheck.NewMetricsHandler(healthcheck.NewHandler(), registry)
+
+	// Create the new internalserver Handler
+	h := NewHandler(
+		WithHealthchecks(healthchecks),
+		WithPrometheusRegistry(registry),
+	)
+
+	// Make a HTTP request against the internalserver Handler
+	fmt.Print(dumpRequest(h, http.MethodGet, "/"))
+
+	// Output:
+	// HTTP/1.1 200 OK
+	// Connection: close
+	// Content-Type: text/html; charset=utf-8
+	//
+	// <html><head><title>Internal</title></head><body>
+	// <p><a href='/live'>/live - Exposes liveness checks</a></p>
+	// <p><a href='/metrics'>/metrics - Exposes Prometheus metrics</a></p>
+	// <p><a href='/ready'>/ready - Exposes readiness checks</a></p>
+	// </body></html>
+}
+
+func Example_custom_endpoint() {
+	registry := prometheus.NewRegistry()
+
+	// Create the new internalserver Handler like normal.
+	h := NewHandler(
+		WithPrometheusRegistry(registry),
+	)
+
+	// Add a custom endpoint to the internal handler also registering it with the index page.
+	h.AddEndpoint("/foo", "My other signal to expose internally",
+		func(w http.ResponseWriter, r *http.Request) {
+		},
+	)
+
+	// Make a HTTP request against the internalserver Handler
+	fmt.Print(dumpRequest(h, http.MethodGet, "/"))
+
+	// Output:
+	// HTTP/1.1 200 OK
+	// Connection: close
+	// Content-Type: text/html; charset=utf-8
+	//
+	// <html><head><title>Internal</title></head><body>
+	// <p><a href='/foo'>/foo - My other signal to expose internally</a></p>
+	// <p><a href='/metrics'>/metrics - Exposes Prometheus metrics</a></p>
+	// </body></html>
+}
+
+func dumpRequest(handler http.Handler, method string, path string) string {
+	req, err := http.NewRequest(method, path, nil)
+	if err != nil {
+		panic(err)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	dump, err := httputil.DumpResponse(rr.Result(), true)
+	if err != nil {
+		panic(err)
+	}
+	return strings.Replace(string(dump), "\r\n", "\n", -1)
+}

--- a/internalserver/handler.go
+++ b/internalserver/handler.go
@@ -1,0 +1,104 @@
+package internalserver
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"sort"
+
+	"github.com/metalmatze/signal/healthcheck"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type Handler struct {
+	http.ServeMux
+	endpoints map[string]string
+}
+
+func NewHandler(options ...Option) *Handler {
+	h := &Handler{endpoints: map[string]string{}}
+
+	h.HandleFunc("/", h.index)
+
+	for _, option := range options {
+		option(h)
+	}
+
+	return h
+}
+
+func (h *Handler) AddEndpoint(pattern string, description string, handler http.HandlerFunc) {
+	h.endpoints[pattern] = description
+	h.HandleFunc(pattern, handler)
+}
+
+func (h *Handler) index(w http.ResponseWriter, r *http.Request) {
+	html := "<html><head><title>Internal</title></head><body>\n"
+
+	// No follows some sorting of endpoints to always show them in the same order.
+	type endpoint struct {
+		Pattern     string
+		Description string
+	}
+	var endpoints []endpoint
+
+	for p, d := range h.endpoints {
+		endpoints = append(endpoints, endpoint{Pattern: p, Description: d})
+	}
+	sort.Slice(endpoints, func(i, j int) bool {
+		return endpoints[i].Pattern < endpoints[j].Pattern
+	})
+
+	for _, e := range endpoints {
+		html += fmt.Sprintf("<p><a href='%s'>%s - %s</a></p>\n", e.Pattern, e.Pattern, e.Description)
+	}
+	html += `</body></html>`
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(html))
+}
+
+type Option func(h *Handler)
+
+func WithHealthchecks(healthchecks healthcheck.Handler) Option {
+	return func(h *Handler) {
+		h.AddEndpoint(
+			"/live",
+			"Exposes liveness checks",
+			healthchecks.LiveEndpoint,
+		)
+		h.AddEndpoint(
+			"/ready",
+			"Exposes readiness checks",
+			healthchecks.ReadyEndpoint,
+		)
+	}
+}
+
+func WithPrometheusRegistry(registry *prometheus.Registry) Option {
+	return func(h *Handler) {
+		h.AddEndpoint(
+			"/metrics",
+			"Exposes Prometheus metrics",
+			promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP,
+		)
+	}
+}
+
+func WithPProf() Option {
+	return func(h *Handler) {
+		m := http.NewServeMux()
+		m.HandleFunc("/debug/pprof/*", pprof.Index)
+		m.HandleFunc("/pprof/cmdline", pprof.Cmdline)
+		m.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		m.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		m.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+		h.AddEndpoint(
+			"/debug",
+			"Exposes pprof endpoints to consume via HTTP",
+			m.ServeHTTP,
+		)
+	}
+}

--- a/internalserver/handler.go
+++ b/internalserver/handler.go
@@ -15,6 +15,7 @@ import (
 type Handler struct {
 	http.ServeMux
 	endpoints []endpoint
+	name      string
 }
 
 // endpoint has a description to a pattern.
@@ -25,7 +26,7 @@ type endpoint struct {
 
 // NewHandler creates a new internalserver Handler.
 func NewHandler(options ...Option) *Handler {
-	h := &Handler{}
+	h := &Handler{name: "Internal"}
 
 	for _, option := range options {
 		option(h)
@@ -43,14 +44,10 @@ func (h *Handler) AddEndpoint(pattern string, description string, handler http.H
 		Description: description,
 	})
 
-	//"Cache-Control":   "no-cache, no-store, no-transform, must-revalidate, private, max-age=0",
-
 	// Sort endpoints by pattern after adding a new one, to always show them in the same order.
 	sort.Slice(h.endpoints, func(i, j int) bool {
 		return h.endpoints[i].Pattern < h.endpoints[j].Pattern
 	})
-
-	fmt.Println("Adding handler for", pattern)
 
 	h.HandleFunc(pattern, handler)
 }
@@ -69,6 +66,13 @@ func (h *Handler) index(w http.ResponseWriter, r *http.Request) {
 
 // Option is a func that modifies the configuration for the internalserver handler.
 type Option func(h *Handler)
+
+// WithName allows to set an application name for the internalserver handler.
+func WithName(name string) Option {
+	return func(h *Handler) {
+		h.name = name
+	}
+}
 
 // WithHealthchecks adds the healthchecks endpoints /live and /ready to the internalserver.
 func WithHealthchecks(healthchecks healthcheck.Handler) Option {

--- a/internalserver/handler_test.go
+++ b/internalserver/handler_test.go
@@ -1,0 +1,24 @@
+package internalserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandler_AddEndpoint(t *testing.T) {
+	h := NewHandler()
+	h.AddEndpoint("/foo", "some handler", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("bar"))
+	})
+
+	assert.Equal(t, "some handler", h.endpoints["/foo"])
+
+	rr := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/foo", nil)
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, "bar", rr.Body.String())
+}

--- a/internalserver/handler_test.go
+++ b/internalserver/handler_test.go
@@ -14,7 +14,8 @@ func TestHandler_AddEndpoint(t *testing.T) {
 		_, _ = w.Write([]byte("bar"))
 	})
 
-	assert.Equal(t, "some handler", h.endpoints["/foo"])
+	assert.Len(t, h.endpoints, 1)
+	assert.Equal(t, endpoint{Pattern: "/foo", Description: "some handler"}, h.endpoints[0])
 
 	rr := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, "/foo", nil)


### PR DESCRIPTION
The idea is to mostly lift the need to always register metrics and healthchecks the same way in every other project and as a side-effect get a "nice" index page for the internal server.

/cc @kakkoyun @squat