### PR TITLE
Add name as headline and title in internalserver

### DIFF
--- a/internalserver/example_test.go
+++ b/internalserver/example_test.go
@@ -30,6 +30,7 @@ func Example() {
 	// Content-Type: text/html; charset=utf-8
 	//
 	// <html><head><title>Internal</title></head><body>
+	// <h1>Internal</h1>
 	// <p><a href='/live'>/live - Exposes liveness checks</a></p>
 	// <p><a href='/metrics'>/metrics - Exposes Prometheus metrics</a></p>
 	// <p><a href='/ready'>/ready - Exposes readiness checks</a></p>
@@ -59,6 +60,7 @@ func Example_custom_endpoint() {
 	// Content-Type: text/html; charset=utf-8
 	//
 	// <html><head><title>Internal</title></head><body>
+	// <h1>Internal</h1>
 	// <p><a href='/foo'>/foo - My other signal to expose internally</a></p>
 	// <p><a href='/metrics'>/metrics - Exposes Prometheus metrics</a></p>
 	// </body></html>

--- a/internalserver/handler.go
+++ b/internalserver/handler.go
@@ -53,7 +53,8 @@ func (h *Handler) AddEndpoint(pattern string, description string, handler http.H
 }
 
 func (h *Handler) index(w http.ResponseWriter, r *http.Request) {
-	html := "<html><head><title>Internal</title></head><body>\n"
+	html := fmt.Sprintf("<html><head><title>%s</title></head><body>\n", h.name)
+	html += fmt.Sprintf("<h1>%s</h1>\n", h.name)
 
 	for _, e := range h.endpoints {
 		html += fmt.Sprintf("<p><a href='%s'>%s - %s</a></p>\n", e.Pattern, e.Pattern, e.Description)


### PR DESCRIPTION
I was just wondering why setting the name through the option `internalserver.Name()` didn't do anything. Turns out we never actually used it.