### PR TITLE
internalserver/handler.go: add WithPrometheusGatherer option

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,4 +23,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37
+          version: v1.51

--- a/healthcheck/timeout_test.go
+++ b/healthcheck/timeout_test.go
@@ -34,7 +34,7 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("expected Timeout() to be true, got %v", err)
 	}
 
-	if netErr, ok := err.(net.Error); !ok || !netErr.Temporary() {
+	if netErr, ok := err.(net.Error); !ok || !netErr.Temporary() { //nolint:staticcheck
 		t.Errorf("expected Temporary() to be true, got %v", err)
 	}
 

--- a/internalserver/handler.go
+++ b/internalserver/handler.go
@@ -107,11 +107,16 @@ func WithHealthchecks(healthchecks healthcheck.Handler) Option {
 
 // WithPrometheusRegistry adds a /metrics endpoint to the internalserver.
 func WithPrometheusRegistry(registry *prometheus.Registry) Option {
+	return WithPrometheusGatherer(registry)
+}
+
+// WithPrometheusGatherer adds a /metrics endpoint to the internalserver.
+func WithPrometheusGatherer(gatherer prometheus.Gatherer) Option {
 	return func(h *Handler) {
 		h.AddEndpoint(
 			"/metrics",
 			"Exposes Prometheus metrics",
-			promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP,
+			promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}).ServeHTTP,
 		)
 	}
 }


### PR DESCRIPTION
Sometime you don't have a `prometheus.Registry`, but only a
`prometheus.Gatherer` to create the http handler.
And since the `promhttp.HandlerFor` only requires a
`prometheus.Gatherer`, there is no reason to only accept
the concrete type of `prometheus.Registry`.

Signed-off-by: leonnicolas <leonloechner@gmx.de>
